### PR TITLE
feat(#7,8,9,10) 도서관 즐겨찾기 등록,삭제,조회 구현 및 도서관 정보나루 api 연동과 도서관 정보 DB 저장, 스케줄러, 관리자 수동 동기화

### DIFF
--- a/bookitout-back/bookitout/build.gradle
+++ b/bookitout-back/bookitout/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // 최신 JWT 구성
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/BookitoutApplication.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/BookitoutApplication.java
@@ -2,8 +2,10 @@ package com.hjeu.bookitout;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BookitoutApplication {
 
     public static void main(String[] args) {

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/config/WebClientConfig.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/config/WebClientConfig.java
@@ -1,0 +1,20 @@
+package com.hjeu.bookitout.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient libraryApiWebClient() {
+        return WebClient.builder()
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(configurer -> configurer
+                                .defaultCodecs()
+                                .maxInMemorySize(5 * 1024 * 1024)) // 5MB로 설정
+                        .build())
+                .build();
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/application/scheduler/LibrarySyncScheduler.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/application/scheduler/LibrarySyncScheduler.java
@@ -1,9 +1,12 @@
 package com.hjeu.bookitout.library.application.scheduler;
 
 import com.hjeu.bookitout.library.service.LibrarySyncService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class LibrarySyncScheduler {
 
@@ -12,5 +15,12 @@ public class LibrarySyncScheduler {
     @Autowired
     public LibrarySyncScheduler(LibrarySyncService librarySyncService) {
         this.librarySyncService = librarySyncService;
+    }
+
+    @Scheduled(cron = "0 0 0 1 * ?")    // 매월 1일 자정
+    public void autoSyncLibraryData() {
+        log.info("도서관 정보 스케줄러 시작");
+        librarySyncService.syncLibraryData();
+        log.info("도서관 정보 스케줄러 끝");
     }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/application/scheduler/LibrarySyncScheduler.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/application/scheduler/LibrarySyncScheduler.java
@@ -1,0 +1,16 @@
+package com.hjeu.bookitout.library.application.scheduler;
+
+import com.hjeu.bookitout.library.service.LibrarySyncService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LibrarySyncScheduler {
+
+    private final LibrarySyncService librarySyncService;
+
+    @Autowired
+    public LibrarySyncScheduler(LibrarySyncService librarySyncService) {
+        this.librarySyncService = librarySyncService;
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/controller/AdminLibraryController.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/controller/AdminLibraryController.java
@@ -1,0 +1,26 @@
+package com.hjeu.bookitout.library.controller;
+
+import com.hjeu.bookitout.library.service.LibrarySyncService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/library")
+public class AdminLibraryController {
+
+    private final LibrarySyncService librarySyncService;
+
+    @Autowired
+    public AdminLibraryController(LibrarySyncService librarySyncService) {
+        this.librarySyncService = librarySyncService;
+    }
+
+    @PostMapping("/sync")
+    public ResponseEntity<?> manualSync() {
+        librarySyncService.syncLibraryData();
+        return ResponseEntity.ok("동기화 완료");
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/controller/LibraryController.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/controller/LibraryController.java
@@ -1,0 +1,29 @@
+package com.hjeu.bookitout.library.controller;
+
+import com.hjeu.bookitout.library.domain.Library;
+import com.hjeu.bookitout.library.service.LibraryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/libraries")
+public class LibraryController {
+
+    private final LibraryService libraryService;
+
+    @Autowired
+    public LibraryController(LibraryService libraryService) {
+        this.libraryService = libraryService;
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Library>> search(@RequestParam("libName") String libName) {
+        return ResponseEntity.ok(libraryService.searchLibrariesByLibName(libName));
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/domain/Library.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/domain/Library.java
@@ -1,0 +1,48 @@
+package com.hjeu.bookitout.library.domain;
+
+import com.hjeu.bookitout.library.dto.LibraryOpenApiResponse;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tb_library")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Library {
+
+    @Id
+    @Column(name = "lib_code", nullable = false)
+    private String libCode;
+
+    @Column(name = "lib_name")
+    private String libName;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "homepage_url")
+    private String homepageUrl;
+
+    public static Library fromOpenApi(LibraryOpenApiResponse.LibraryRaw raw) {
+        return Library.builder()
+                .libCode(raw.getLibCode())
+                .libName(raw.getLibName())
+                .homepageUrl(raw.getHomepage())
+                .address(raw.getAddress())
+                .build();
+    }
+
+    public void updateFrom(Library other) {
+        this.libName = other.getLibName();
+        this.homepageUrl = other.getHomepageUrl();
+        this.address = other.getAddress();
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/dto/LibraryOpenApiResponse.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/dto/LibraryOpenApiResponse.java
@@ -1,0 +1,41 @@
+package com.hjeu.bookitout.library.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LibraryOpenApiResponse {
+
+    private Response response;
+
+    public List<LibraryRaw> getLibs() {
+        if (response == null || response.libs == null) return List.of();
+        return response.libs.stream()
+                .map(LibWrapper::getLib)
+                .toList();
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+        private List<LibWrapper> libs;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LibWrapper {
+        private LibraryRaw lib;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LibraryRaw {
+        private String libCode;
+        private String libName;
+        private String homepage;
+        private String address;
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/repository/LibraryRepository.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/repository/LibraryRepository.java
@@ -1,0 +1,15 @@
+package com.hjeu.bookitout.library.repository;
+
+import com.hjeu.bookitout.library.domain.Library;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface LibraryRepository extends JpaRepository<Library, String> {
+    List<Library> findByLibNameContainingIgnoreCase(String libName);
+
+    Optional<Library> findByLibCode(String libCode);
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibraryService.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibraryService.java
@@ -1,0 +1,9 @@
+package com.hjeu.bookitout.library.service;
+
+import com.hjeu.bookitout.library.domain.Library;
+
+import java.util.List;
+
+public interface LibraryService {
+    List<Library> searchLibrariesByLibName(String libName);
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibraryServiceImpl.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibraryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.hjeu.bookitout.library.service;
+
+import com.hjeu.bookitout.library.domain.Library;
+import com.hjeu.bookitout.library.repository.LibraryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class LibraryServiceImpl implements LibraryService {
+
+    private final LibraryRepository libraryRepository;
+
+    @Autowired
+    public LibraryServiceImpl(LibraryRepository libraryRepository) {
+        this.libraryRepository = libraryRepository;
+    }
+
+    @Override
+    public List<Library> searchLibrariesByLibName(String libName) {
+        return libraryRepository.findByLibNameContainingIgnoreCase(libName);
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibrarySyncService.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibrarySyncService.java
@@ -1,0 +1,5 @@
+package com.hjeu.bookitout.library.service;
+
+public interface LibrarySyncService {
+    void syncLibraryData();
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibrarySyncServiceImpl.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library/service/LibrarySyncServiceImpl.java
@@ -1,0 +1,61 @@
+package com.hjeu.bookitout.library.service;
+
+import com.hjeu.bookitout.library.domain.Library;
+import com.hjeu.bookitout.library.dto.LibraryOpenApiResponse;
+import com.hjeu.bookitout.library.repository.LibraryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LibrarySyncServiceImpl implements LibrarySyncService {
+
+    private final LibraryRepository libraryRepository;
+    private final WebClient webClient;
+
+    @Value("${library.api.key}")
+    private String apiKey;
+
+    @Autowired
+    public LibrarySyncServiceImpl(LibraryRepository libraryRepository, WebClient webClient) {
+        this.libraryRepository = libraryRepository;
+        this.webClient = webClient;
+    }
+
+public List<Library> fetchLibrariesFromOpenAPI() {
+    String url = "http://data4library.kr/api/libSrch?authKey=" + apiKey + "&pageNo=1&pageSize=1600&format=json";
+
+    LibraryOpenApiResponse response = webClient.get()
+            .uri(url)
+            .retrieve()
+            .bodyToMono(LibraryOpenApiResponse.class)
+            .block();
+
+    return response.getLibs()
+            .stream()
+            .map(Library::fromOpenApi)
+            .collect(Collectors.toList());
+}
+
+    @Transactional
+    @Override
+    public void syncLibraryData() {
+        List<Library> libraries = fetchLibrariesFromOpenAPI();
+        for (Library lib : libraries) {
+            libraryRepository.findByLibCode(lib.getLibCode())
+                    .ifPresentOrElse(
+                            existing -> {
+                                if (!existing.equals(lib)) {
+                                    existing.updateFrom(lib); // 필드 값만 수정
+                                }
+                            },
+                            () -> libraryRepository.save(lib) // 새로 추가
+                    );
+        }
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
@@ -1,4 +1,36 @@
 package com.hjeu.bookitout.library_favorite.controller;
 
+import com.hjeu.bookitout.library_favorite.dto.LibraryFavoriteDTO;
+import com.hjeu.bookitout.library_favorite.service.LibraryFavoriteService;
+import com.hjeu.bookitout.library_favorite.vo.request.LibraryFavoriteRequestVO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/library")
 public class LibraryFavoriteController {
+
+    private final LibraryFavoriteService libraryFavoriteService;
+
+    @Autowired
+    public LibraryFavoriteController(LibraryFavoriteService libraryFavoriteService) {
+        this.libraryFavoriteService = libraryFavoriteService;
+    }
+
+    @PostMapping("/favorite")
+    public ResponseEntity<?> addLibraryFavorite(@RequestBody LibraryFavoriteRequestVO request,
+                                                @AuthenticationPrincipal String userId) {
+        LibraryFavoriteDTO dto = LibraryFavoriteDTO.builder()
+                        .userId(userId)
+                        .libName(request.getLibName())
+                        .libUrl(request.getLibUrl())
+                        .build();
+        libraryFavoriteService.addFavoriteLibrary(dto);
+        return ResponseEntity.ok("도서관 즐겨찾기 등록 완료");
+    }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
@@ -3,13 +3,13 @@ package com.hjeu.bookitout.library_favorite.controller;
 import com.hjeu.bookitout.library_favorite.dto.LibraryFavoriteDTO;
 import com.hjeu.bookitout.library_favorite.service.LibraryFavoriteService;
 import com.hjeu.bookitout.library_favorite.vo.request.LibraryFavoriteRequestVO;
+import com.hjeu.bookitout.library_favorite.vo.response.LibraryFavoriteResponseVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/library")
@@ -22,6 +22,7 @@ public class LibraryFavoriteController {
         this.libraryFavoriteService = libraryFavoriteService;
     }
 
+    // 도서관 즐겨찾기 등록
     @PostMapping("/favorite")
     public ResponseEntity<?> addLibraryFavorite(@RequestBody LibraryFavoriteRequestVO request,
                                                 @AuthenticationPrincipal String userId) {
@@ -32,5 +33,12 @@ public class LibraryFavoriteController {
                         .build();
         libraryFavoriteService.addFavoriteLibrary(dto);
         return ResponseEntity.ok("도서관 즐겨찾기 등록 완료");
+    }
+
+    // 도서관 즐겨찾기 조회
+    @GetMapping("/favorite")
+    public ResponseEntity<?> getLibraryFavorite(@AuthenticationPrincipal String userId) {
+        List<LibraryFavoriteResponseVO> favorites = libraryFavoriteService.getLibraryFavorite(userId);
+        return ResponseEntity.ok(favorites);
     }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
@@ -5,6 +5,7 @@ import com.hjeu.bookitout.library_favorite.service.LibraryFavoriteService;
 import com.hjeu.bookitout.library_favorite.vo.request.LibraryFavoriteRequestVO;
 import com.hjeu.bookitout.library_favorite.vo.response.LibraryFavoriteResponseVO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -40,5 +41,17 @@ public class LibraryFavoriteController {
     public ResponseEntity<?> getLibraryFavorite(@AuthenticationPrincipal String userId) {
         List<LibraryFavoriteResponseVO> favorites = libraryFavoriteService.getLibraryFavorite(userId);
         return ResponseEntity.ok(favorites);
+    }
+
+    // 도서관 즐겨찾기 삭제
+    @PatchMapping("/favorite/{libId}")
+    public ResponseEntity<?> deleteFavorite(@PathVariable Long libId,
+                                            @AuthenticationPrincipal String userId) {
+        try {
+            libraryFavoriteService.deleteFavorite(libId, userId);
+            return ResponseEntity.ok("도서관 즐겨찾기 삭제 완료");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
     }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/library")
+@RequestMapping("/api/v1/library-favorite")
 public class LibraryFavoriteController {
 
     private final LibraryFavoriteService libraryFavoriteService;

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/controller/LibraryFavoriteController.java
@@ -1,0 +1,4 @@
+package com.hjeu.bookitout.library_favorite.controller;
+
+public class LibraryFavoriteController {
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/domain/LibraryFavorite.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/domain/LibraryFavorite.java
@@ -41,4 +41,8 @@ public class LibraryFavorite {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    public void deactivate() {
+        this.status = false;
+    }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/domain/LibraryFavorite.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/domain/LibraryFavorite.java
@@ -1,0 +1,38 @@
+package com.hjeu.bookitout.LibraryFavorite.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "library_favorite")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LibraryFavorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long libId;
+
+    @Column(name = "lib_name", nullable = false)
+    private String libName;
+
+    @Column(name = "lib_url", nullable = false)
+    private String libUrl;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/domain/LibraryFavorite.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/domain/LibraryFavorite.java
@@ -1,4 +1,4 @@
-package com.hjeu.bookitout.LibraryFavorite.domain;
+package com.hjeu.bookitout.library_favorite.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "library_favorite")
+@Table(name = "tb_lib_favorite")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -25,8 +25,14 @@ public class LibraryFavorite {
     @Column(name = "lib_url", nullable = false)
     private String libUrl;
 
+    @Column(name = "status", nullable = false)
+    private boolean status = true;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @Column(name = "user_id", nullable = false)
     private String userId;

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/dto/LibraryFavoriteDTO.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/dto/LibraryFavoriteDTO.java
@@ -1,0 +1,4 @@
+package com.hjeu.bookitout.library_favorite.dto;
+
+public class LibraryFavoriteDTO {
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/dto/LibraryFavoriteDTO.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/dto/LibraryFavoriteDTO.java
@@ -1,4 +1,19 @@
 package com.hjeu.bookitout.library_favorite.dto;
 
+import jakarta.persistence.Column;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
 public class LibraryFavoriteDTO {
+    private Long libId;
+    private String libName;
+    private String libUrl;
+    private LocalDateTime createdAt;
+    private String userId;
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LibraryFavoriteRepository extends JpaRepository<LibraryFavorite, Long> {
     List<LibraryFavorite> findByUserIdAndStatusTrue(String userId);
+
+    Optional<LibraryFavorite> findByLibIdAndUserId(Long libId, String userId);
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
@@ -1,0 +1,4 @@
+package com.hjeu.bookitout.library_favorite.repository;
+
+public interface LibraryFavoriteRepository {
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
@@ -1,4 +1,9 @@
 package com.hjeu.bookitout.library_favorite.repository;
 
-public interface LibraryFavoriteRepository {
+import com.hjeu.bookitout.library_favorite.domain.LibraryFavorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LibraryFavoriteRepository extends JpaRepository<LibraryFavorite, Long> {
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/repository/LibraryFavoriteRepository.java
@@ -4,6 +4,9 @@ import com.hjeu.bookitout.library_favorite.domain.LibraryFavorite;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LibraryFavoriteRepository extends JpaRepository<LibraryFavorite, Long> {
+    List<LibraryFavorite> findByUserIdAndStatusTrue(String userId);
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
@@ -1,4 +1,7 @@
 package com.hjeu.bookitout.library_favorite.service;
 
+import com.hjeu.bookitout.library_favorite.dto.LibraryFavoriteDTO;
+
 public interface LibraryFavoriteService {
+    void addFavoriteLibrary(LibraryFavoriteDTO dto);
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
@@ -1,0 +1,4 @@
+package com.hjeu.bookitout.library_favorite.service;
+
+public interface LibraryFavoriteService {
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
@@ -1,7 +1,12 @@
 package com.hjeu.bookitout.library_favorite.service;
 
 import com.hjeu.bookitout.library_favorite.dto.LibraryFavoriteDTO;
+import com.hjeu.bookitout.library_favorite.vo.response.LibraryFavoriteResponseVO;
+
+import java.util.List;
 
 public interface LibraryFavoriteService {
     void addFavoriteLibrary(LibraryFavoriteDTO dto);
+
+    List<LibraryFavoriteResponseVO> getLibraryFavorite(String userId);
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteService.java
@@ -9,4 +9,6 @@ public interface LibraryFavoriteService {
     void addFavoriteLibrary(LibraryFavoriteDTO dto);
 
     List<LibraryFavoriteResponseVO> getLibraryFavorite(String userId);
+
+    void deleteFavorite(Long libId, String userId);
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
@@ -1,4 +1,29 @@
 package com.hjeu.bookitout.library_favorite.service;
 
-public class LibraryFavoriteServiceImpl {
+import com.hjeu.bookitout.library_favorite.domain.LibraryFavorite;
+import com.hjeu.bookitout.library_favorite.dto.LibraryFavoriteDTO;
+import com.hjeu.bookitout.library_favorite.repository.LibraryFavoriteRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LibraryFavoriteServiceImpl implements LibraryFavoriteService {
+
+    private final LibraryFavoriteRepository libraryFavoriteRepository;
+
+    @Autowired
+    public LibraryFavoriteServiceImpl(LibraryFavoriteRepository libraryFavoriteRepository) {
+        this.libraryFavoriteRepository = libraryFavoriteRepository;
+    }
+
+    @Override
+    public void addFavoriteLibrary(LibraryFavoriteDTO dto) {
+        LibraryFavorite favorite = LibraryFavorite.builder()
+                .userId(dto.getUserId())
+                .libName(dto.getLibName())
+                .libUrl(dto.getLibUrl())
+                .status(true)
+                .build();
+        libraryFavoriteRepository.save(favorite);
+    }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
@@ -1,0 +1,4 @@
+package com.hjeu.bookitout.library_favorite.service;
+
+public class LibraryFavoriteServiceImpl {
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
@@ -3,8 +3,11 @@ package com.hjeu.bookitout.library_favorite.service;
 import com.hjeu.bookitout.library_favorite.domain.LibraryFavorite;
 import com.hjeu.bookitout.library_favorite.dto.LibraryFavoriteDTO;
 import com.hjeu.bookitout.library_favorite.repository.LibraryFavoriteRepository;
+import com.hjeu.bookitout.library_favorite.vo.response.LibraryFavoriteResponseVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class LibraryFavoriteServiceImpl implements LibraryFavoriteService {
@@ -25,5 +28,13 @@ public class LibraryFavoriteServiceImpl implements LibraryFavoriteService {
                 .status(true)
                 .build();
         libraryFavoriteRepository.save(favorite);
+    }
+
+    @Override
+    public List<LibraryFavoriteResponseVO> getLibraryFavorite(String userId) {
+        List<LibraryFavorite> list = libraryFavoriteRepository.findByUserIdAndStatusTrue(userId);
+        return list.stream()
+                .map(f -> new LibraryFavoriteResponseVO(f.getLibName(), f.getLibUrl()))
+                .toList();
     }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/service/LibraryFavoriteServiceImpl.java
@@ -37,4 +37,12 @@ public class LibraryFavoriteServiceImpl implements LibraryFavoriteService {
                 .map(f -> new LibraryFavoriteResponseVO(f.getLibName(), f.getLibUrl()))
                 .toList();
     }
+
+    @Override
+    public void deleteFavorite(Long libId, String userId) {
+        LibraryFavorite favorite = libraryFavoriteRepository.findByLibIdAndUserId(libId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 즐겨찾기를 찾을 수 없습니다."));
+        favorite.deactivate();
+        libraryFavoriteRepository.save(favorite);
+    }
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/vo/request/LibraryFavoriteRequestVO.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/vo/request/LibraryFavoriteRequestVO.java
@@ -1,4 +1,15 @@
 package com.hjeu.bookitout.library_favorite.vo.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class LibraryFavoriteRequestVO {
+    private String libName;
+    private String libUrl;
 }

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/vo/request/LibraryFavoriteRequestVO.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/vo/request/LibraryFavoriteRequestVO.java
@@ -1,0 +1,4 @@
+package com.hjeu.bookitout.library_favorite.vo.request;
+
+public class LibraryFavoriteRequestVO {
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/vo/response/LibraryFavoriteResponseVO.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/library_favorite/vo/response/LibraryFavoriteResponseVO.java
@@ -1,0 +1,13 @@
+package com.hjeu.bookitout.library_favorite.vo.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LibraryFavoriteResponseVO {
+    private String libName;
+    private String libUrl;
+}

--- a/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/user/domain/User.java
+++ b/bookitout-back/bookitout/src/main/java/com/hjeu/bookitout/user/domain/User.java
@@ -32,7 +32,7 @@ public class User {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "deleted_at", nullable = true)
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @PrePersist

--- a/bookitout-back/bookitout/src/main/resources/application.yml
+++ b/bookitout-back/bookitout/src/main/resources/application.yml
@@ -14,3 +14,7 @@ spring:
       port: ${REDIS_PORT}
 
 secret-key: ${SECRET_KEY}
+
+library:
+  api:
+    key: ${LIBRARY_API_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #7 #8 #9 #10 

## 📍코드 변경 사유
- [x] 신규 기능 추가
- [ ] 기존 기능 수정
- [ ] 버그 수정

## 📝작업 내용

> 
- 도서관 즐겨찾기 등록, 삭제, 조회
- 도서관 정보나루 api 연동
- 도서관 정보 DB 저장
- 관리자 수동 동기화
- 도서관 api 매월 1일 자정 스케줄러 추가
- 도서관 조회

<img width="751" alt="스크린샷 2025-06-02 오후 3 28 10" src="https://github.com/user-attachments/assets/9db096f3-267b-43bc-a70e-d92fda45f3b4" />
<img width="619" alt="스크린샷 2025-06-02 오후 3 34 43" src="https://github.com/user-attachments/assets/a0ccbf75-c599-4da9-afab-81095458cc4c" />
