### PR TITLE
fix: nginx-conf/default.conf 파일에서 SSL/HTTPS 관련 설정을 주석 처리

### DIFF
--- a/nginx-conf/default.conf
+++ b/nginx-conf/default.conf
@@ -20,6 +20,14 @@ server {
         try_files $uri $uri/ /index.html; # React Router와 같은 SPA를 위한 설정
     }
 
+    # SSL 설정을 위한 별도의 server 블록이 필요할 수 있습니다.
+    # 지금은 주석 처리합니다.
+    # listen 443 ssl;
+    # ssl_certificate /etc/nginx/ssl/live/bookitout.site/fullchain.pem;
+    # ssl_certificate_key /etc/nginx/ssl/live/bookitout.site/privkey.pem;
+    # include /etc/letsencrypt/options-ssl-nginx.conf;
+    # ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
     # API 요청을 백엔드로 프록시 (필요시 추가)
     # location /api/ {
     #     proxy_pass http://backend:8000;


### PR DESCRIPTION
nginx-conf/default.conf 파일에서 SSL/HTTPS 관련 설정을 주석 처리