### PR TITLE
fix: nginx-conf/default.conf 파일에서 SSL 관련 설정 라인들을 완전히 제거

### DIFF
--- a/nginx-conf/default.conf
+++ b/nginx-conf/default.conf
@@ -9,9 +9,6 @@ server {
         root /var/www/certbot;
     }
 
-    # HTTPS로 리다이렉션 (인증서 발급 후 이 줄의 주석을 해제할 것입니다)
-    # return 301 https://$host$request_uri;
-
     # React/Next.js 프론트엔드 애플리케이션을 서비스하는 설정
     # bookitout-front의 Dockerfile이 빌드된 파일을 /usr/share/nginx/html에 복사한다고 가정합니다.
     location / {
@@ -19,14 +16,6 @@ server {
         index index.html index.htm;
         try_files $uri $uri/ /index.html; # React Router와 같은 SPA를 위한 설정
     }
-
-    # SSL 설정을 위한 별도의 server 블록이 필요할 수 있습니다.
-    # 지금은 주석 처리합니다.
-    # listen 443 ssl;
-    # ssl_certificate /etc/nginx/ssl/live/bookitout.site/fullchain.pem;
-    # ssl_certificate_key /etc/nginx/ssl/live/bookitout.site/privkey.pem;
-    # include /etc/letsencrypt/options-ssl-nginx.conf;
-    # ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     # API 요청을 백엔드로 프록시 (필요시 추가)
     # location /api/ {


### PR DESCRIPTION
nginx-conf/default.conf 파일에서 SSL 관련 설정 라인들을 완전히 제거